### PR TITLE
Simplify print functions

### DIFF
--- a/od01.ts
+++ b/od01.ts
@@ -158,7 +158,7 @@ namespace OD01 {
     //% s.defl="string"
     //% newline.defl=true
     //% weight=88 blockGap=8 inlineInputMode=inline
-    export function printStringPM(s: string, newline: boolean = true) {
+    export function printString(s: string, newline: boolean = true) {
         for (let n = 0; n < s.length; n++) {
             char(s.charAt(n), _cx, _cy, 1)
             _cx += 6

--- a/od01.ts
+++ b/od01.ts
@@ -279,7 +279,7 @@ namespace OD01 {
     }
 
     /**
-     * insert in your On Start block to power up the display
+     * power up the OD01 
      */
     //% blockId="OLED12864_I2C_init" block="initialize OLED"
     //% weight=99 blockGap=8

--- a/od01.ts
+++ b/od01.ts
@@ -179,7 +179,7 @@ namespace OD01 {
     //% newline.defl=true
     //% weight=86 blockGap=8 inlineInputMode=inline
     export function printNumber(num: number, newline: boolean = true) {
-        printString(num.toString(), 1, newline)
+        printString(num.toString(), newline)
     }
 
     /**

--- a/od01.ts
+++ b/od01.ts
@@ -152,7 +152,7 @@ namespace OD01 {
     }
 
         /**
-     * print text to screen - PM01
+     * print text to screen
      */
     //% block="print %s|newline %newline"
     //% s.defl="string"
@@ -170,38 +170,16 @@ namespace OD01 {
             scroll()
         }
     }
-    
-    /**
-     * print text to screen
-     */
-    //% block="print %s|color %color|newline %newline"
-    //% s.defl="string"
-    //% color.max=1 color.min=0 color.defl=1
-    //% newline.defl=true
-    //% weight=88 blockGap=8 inlineInputMode=inline
-    export function printString(s: string, color: number, newline: boolean = true) {
-        for (let n = 0; n < s.length; n++) {
-            char(s.charAt(n), _cx, _cy, color)
-            _cx += 6
-            if (_cx > 120) {
-                scroll()
-            }
-        }
-        if (newline) {
-            scroll()
-        }
-    }
 
-    /**
+     /**
      * print a number to screen 
      */
-    //% block="print number %num|color %color|newline %newline"
+    //% block="print number %num|newline %newline"
     //% s.defl="0"
-    //% color.max=1 color.min=0 color.defl=1
     //% newline.defl=true
     //% weight=86 blockGap=8 inlineInputMode=inline
-    export function printNumber(num: number, color: number, newline: boolean = true) {
-        printString(num.toString(), color, newline)
+    export function printNumber(num: number, newline: boolean = true) {
+        printString(num.toString(), 1, newline)
     }
 
     /**


### PR DESCRIPTION
Colour param has been removed as an input from:
print
printNumber.

These functions are most basic - for use by beginners.  Passing in colour as a param was not necessary - just gave too much choice for these functions